### PR TITLE
Bump netty and fasterxml-jackson for CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
     <properties>
         <awssdk.version>2.33.0</awssdk.version>
         <kcl.version>3.1.3</kcl.version>
-        <netty.version>4.2.7.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.15.0</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.18.6</fasterxml-jackson.version>
         <logback.version>1.3.16</logback.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
## Summary
- Bump `netty.version` from `4.2.7.Final` to `4.2.13.Final`
- Bump `fasterxml-jackson.version` from `2.15.0` to `2.18.6`

Both upgrades address known CVEs in the transitive dependency chain pulled in via the KCL MultiLangDaemon.

## Test plan
- [x] `python setup.py download_jars` resolves the new versions
- [x] `python setup.py install` succeeds
- [ ] Sample consumer (`amazon_kclpy_helper.py --print_command --java $(which java) --properties samples/sample.properties`) runs end-to-end against a Kinesis stream
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)