### PR TITLE
Bump package version to 3.1.3.post1

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ all languages.
 
 ## Release Notes
 
+### Release 3.1.3.post1 (May 21, 2026)
+* Bump netty.version from 4.2.7.Final to 4.2.13.Final
+* Bump fasterxml-jackson.version from 2.15.0 to 2.18.6
+
 ### Release 3.1.3 (October 29, 2025)
 * [#331](https://github.com/awslabs/amazon-kinesis-client-python/pull/331) Upgrade netty.version from 4.2.6.Final to 4.2.7.Final
 * [#333](https://github.com/awslabs/amazon-kinesis-client-python/pull/333) Only include argparse for python version 3.1 and below

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '3.1.3'
+PACKAGE_VERSION = '3.1.3.post1'
 PYTHON_REQUIREMENTS = [
     "boto3",
     # argparse is part of python3.2+


### PR DESCRIPTION
## Summary
- Bump `PACKAGE_VERSION` to `3.1.3.post1` in `setup.py`
- Add `3.1.3.post1` release notes to `README.md` covering the netty and fasterxml-jackson CVE bumps merged in #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)