### PR TITLE
Bump `netty` to 4.2.15.Final

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ all languages.
 
 ## Release Notes
 
+### Release 3.1.3.post2 (June 22, 2026)
+* Bump netty.version from 4.2.13.Final to 4.2.15.Final
+
 ### Release 3.1.3.post1 (May 21, 2026)
 * Bump netty.version from 4.2.7.Final to 4.2.13.Final
 * Bump fasterxml-jackson.version from 2.15.0 to 2.18.6

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <properties>
         <awssdk.version>2.33.0</awssdk.version>
         <kcl.version>3.1.3</kcl.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.18.6</fasterxml-jackson.version>
         <logback.version>1.3.16</logback.version>

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '3.1.3.post1'
+PACKAGE_VERSION = '3.1.3.post2'
 PYTHON_REQUIREMENTS = [
     "boto3",
     # argparse is part of python3.2+


### PR DESCRIPTION
Similar to #2 and #4, we're updating `netty` to solve CVE related issues.

I've manually tested the change with the locally built wheel, and I'm able to poll Kinesis records from LocalStack, also verified that the artifact was built with Netty 4.2.15.Final. 

We should think of automating this with Dependabot + test scripts to do some small smoke tests against LocalStack to verify the library builds properly, and is able to be used. 
We could re-use the sample tests here which is supposed to run against AWS, to run against LS